### PR TITLE
HHH-17865 rename hibernate-jpamodelgen to hibernate-processor

### DIFF
--- a/documentation/documentation.gradle
+++ b/documentation/documentation.gradle
@@ -128,7 +128,7 @@ dependencies {
 	reportAggregation project(':hibernate-vibur')
 	reportAggregation project(':hibernate-ant')
 	reportAggregation project(':hibernate-enhance-maven-plugin')
-	reportAggregation project(':hibernate-jpamodelgen')
+	reportAggregation project(':hibernate-processor')
 
 	asciidoctorGems 'rubygems:rouge:4.1.1'
 
@@ -162,8 +162,8 @@ dependencies {
 	jcache project( ':hibernate-jcache' )
 	javadocSources project( path: ':hibernate-jcache', configuration: 'javadocSources' )
 
-	jpamodelgen project( ':hibernate-jpamodelgen' )
-	javadocSources project( path: ':hibernate-jpamodelgen', configuration: 'javadocSources' )
+	jpamodelgen project( ':hibernate-processor' )
+	javadocSources project( path: ':hibernate-processor', configuration: 'javadocSources' )
 
 	javadocClasspath libs.loggingAnnotations
 	javadocClasspath jakartaLibs.validation

--- a/documentation/src/main/asciidoc/introduction/Configuration.adoc
+++ b/documentation/src/main/asciidoc/introduction/Configuration.adoc
@@ -102,7 +102,7 @@ or `org.slf4j:slf4j-jdk14`
 | A JDBC connection pool, for example, {agroal}[Agroal] |
 `org.hibernate.orm:hibernate-agroal` +
 and `io.agroal:agroal-pool`
-| The {generator}[Hibernate Metamodel Generator], especially if you're using the JPA criteria query API | `org.hibernate.orm:hibernate-jpamodelgen`
+| The {generator}[Hibernate Metamodel Generator], especially if you're using the JPA criteria query API | `org.hibernate.orm:hibernate-processor`
 | The {query-validator}[Query Validator], for compile-time checking of HQL | `org.hibernate:query-validator`
 | {validator}[Hibernate Validator], an implementation of {bean-validation}[Bean Validation] |
 `org.hibernate.validator:hibernate-validator` +

--- a/documentation/src/main/asciidoc/introduction/Introduction.adoc
+++ b/documentation/src/main/asciidoc/introduction/Introduction.adoc
@@ -168,7 +168,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
 
     // JPA Metamodel Generator
-    annotationProcessor 'org.hibernate.orm:hibernate-jpamodelgen:{fullVersion}'
+    annotationProcessor 'org.hibernate.orm:hibernate-processor:{fullVersion}'
 
     // Compile-time checking for HQL
     //implementation 'org.hibernate:query-validator:2.0-SNAPSHOT'

--- a/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
+++ b/documentation/src/main/asciidoc/quickstart/guides/obtaining.adoc
@@ -42,7 +42,7 @@ transitive dependencies based on the features being used or not.
 |hibernate-core| The core object/relational mapping engine
 |hibernate-envers| Entity versioning and auditing
 |hibernate-spatial| Support for spatial/GIS data types using https://github.com/GeoLatte/geolatte-geom[GeoLatte]
-|hibernate-jpamodelgen| An annotation processor that generates a JPA-compliant metamodel, plus optional Hibernate extras
+|hibernate-processor| An annotation processor that generates a JPA-compliant metamodel, plus optional Hibernate extras
 |===
 
 [cols="40m,~"]

--- a/documentation/src/main/asciidoc/userguide/chapters/tooling/extras/maven-example-metamodel.pom
+++ b/documentation/src/main/asciidoc/userguide/chapters/tooling/extras/maven-example-metamodel.pom
@@ -9,7 +9,7 @@
                 <annotationProcessorPaths>
                     <path>
                         <groupId>org.hibernate.orm</groupId>
-                        <artifactId>hibernate-jpamodelgen</artifactId>
+                        <artifactId>hibernate-processor</artifactId>
                         <version>$currentHibernateVersion</version>
                         <!-- Optionally exclude transitive dependencies -->
                         <exclusions>

--- a/documentation/src/main/asciidoc/userguide/chapters/tooling/gradle.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/tooling/gradle.adoc
@@ -60,13 +60,13 @@ It also exposes the following method forms:
 ==== Static Metamodel Generation
 
 Static metamodel generation can be incorporated into Gradle builds via the
-annotation processor provided by the `org.hibernate.orm:hibernate-jpamodelgen` artifact.  Applying
+annotation processor provided by the `org.hibernate.orm:hibernate-processor` artifact.  Applying
 an annotation processor in Gradle is super easy -
 
 
 [source,gradle]
 ----
 dependencies {
-    annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen:${hibernateVersion}"
+    annotationProcessor "org.hibernate.orm:hibernate-processor:${hibernateVersion}"
 }
 ----

--- a/documentation/src/main/asciidoc/userguide/chapters/tooling/modelgen.adoc
+++ b/documentation/src/main/asciidoc/userguide/chapters/tooling/modelgen.adoc
@@ -14,7 +14,7 @@
 Jakarta Persistence defines a typesafe Criteria API which allows <<criteria,`Criteria`>>
 queries to be constructed in a strongly-typed manner, utilizing so-called static metamodel
 classes.  The Hibernate Static Metamodel Generator, available via the published
-`org.hibernate.orm:hibernate-jpamodelgen` artifact, is an link:{ann-proc}[annotation processor]
+`org.hibernate.orm:hibernate-processor` artifact, is an link:{ann-proc}[annotation processor]
 used to generate these static metamodel classes.
 
 [NOTE]

--- a/hibernate-core/hibernate-core.gradle
+++ b/hibernate-core/hibernate-core.gradle
@@ -72,7 +72,7 @@ dependencies {
     testRuntimeOnly libs.jacksonXml
     testRuntimeOnly libs.jacksonJsr310
 
-    testAnnotationProcessor project( ':hibernate-jpamodelgen' )
+    testAnnotationProcessor project( ':hibernate-processor' )
 
     // NOTE: it seems like, since 4.10, the Antlr Tool no longer defines
     // transitive dep on the corresponding Antlr Runtime.  At least, I get

--- a/hibernate-core/src/main/java/org/hibernate/annotations/processing/package-info.java
+++ b/hibernate-core/src/main/java/org/hibernate/annotations/processing/package-info.java
@@ -22,7 +22,7 @@
  * <p>
  * Annotations in this package control Hibernate's compile-time
  * tooling, and depend on the use of the annotation processors
- * in the {@code hibernate-jpamodelgen} or {@code query-validator}
+ * in the {@code hibernate-processor} or {@code query-validator}
  * modules. If the appropriate annotation processor is not enabled
  * at build time, these annotations have no effect.
  * <p>

--- a/hibernate-envers/hibernate-envers.gradle
+++ b/hibernate-envers/hibernate-envers.gradle
@@ -20,7 +20,7 @@ dependencies {
 
     compileOnly libs.ant
 
-    annotationProcessor project( ':hibernate-jpamodelgen' )
+    annotationProcessor project( ':hibernate-processor' )
     compileOnly jakartaLibs.annotation
 
     testImplementation project( ':hibernate-testing' )

--- a/hibernate-micrometer/hibernate-micrometer.gradle
+++ b/hibernate-micrometer/hibernate-micrometer.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testImplementation project( ':hibernate-testing' )
 
-    testAnnotationProcessor project( ':hibernate-jpamodelgen' )
+    testAnnotationProcessor project( ':hibernate-processor' )
     testCompileOnly jakartaLibs.annotation
 }
 

--- a/hibernate-platform/hibernate-platform.gradle
+++ b/hibernate-platform/hibernate-platform.gradle
@@ -30,7 +30,7 @@ dependencies {
         api project( ":hibernate-micrometer" )
         api project( ":hibernate-graalvm")
 
-        api project( ":hibernate-jpamodelgen" )
+        api project( ":hibernate-processor" )
         api project( ":hibernate-gradle-plugin" )
         api project( ":hibernate-enhance-maven-plugin" )
         api project( ":hibernate-ant" )

--- a/hibernate-testing/hibernate-testing.gradle
+++ b/hibernate-testing/hibernate-testing.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation libs.jandex
     implementation testLibs.wildFlyTxnClient
 
-    annotationProcessor project( ':hibernate-jpamodelgen' )
+    annotationProcessor project( ':hibernate-processor' )
 }
 
 tasks.checkstyleMain {

--- a/settings.gradle
+++ b/settings.gradle
@@ -342,7 +342,7 @@ if ( "OpenJDK Runtime Environment".equals( System.getProperty( "java.runtime.nam
 
 include 'metamodel-generator'
 project(':metamodel-generator').projectDir = new File(rootProject.projectDir, "tooling/metamodel-generator")
-project(':metamodel-generator').name = 'hibernate-jpamodelgen'
+project(':metamodel-generator').name = 'hibernate-processor'
 
 include 'hibernate-gradle-plugin'
 project(':hibernate-gradle-plugin').projectDir = new File(rootProject.projectDir, "tooling/hibernate-gradle-plugin")

--- a/tooling/metamodel-generator/hibernate-processor.gradle
+++ b/tooling/metamodel-generator/hibernate-processor.gradle
@@ -116,3 +116,62 @@ compileTestJava {
 			"-AsuppressJakartaDataMetamodel=true"
 	]
 }
+
+publishing {
+	publications {
+		// relocation for the published artifacts based on the old groupId
+		relocationPom(MavenPublication) {
+			pom {
+				name = 'hibernate-jpamodelgen - relocation'
+				groupId = 'org.hibernate.orm'
+				artifactId = 'hibernate-jpamodelgen'
+				version = project.version
+
+				description = project.description
+				url = 'https://hibernate.org/orm'
+
+				organization {
+					name = 'Hibernate.org'
+					url = 'https://hibernate.org'
+				}
+
+				licenses {
+					license {
+						name = 'GNU Library General Public License v2.1 or later'
+						url = 'https://www.opensource.org/licenses/LGPL-2.1'
+						comments = 'See discussion at https://hibernate.org/community/license/ for more details.'
+						distribution = 'repo'
+					}
+				}
+
+				scm {
+					url = 'https://github.com/hibernate/hibernate-orm'
+					connection = 'scm:git:https://github.com/hibernate/hibernate-orm.git'
+					developerConnection = 'scm:git:git@github.com:hibernate/hibernate-orm.git'
+				}
+
+				developers {
+					developer {
+						id = 'hibernate-team'
+						name = 'The Hibernate Development Team'
+						organization = 'Hibernate.org'
+						organizationUrl = 'https://hibernate.org'
+					}
+				}
+
+				issueManagement {
+					system = 'jira'
+					url = 'https://hibernate.atlassian.net/browse/HHH'
+				}
+
+				distributionManagement {
+					relocation {
+						groupId = 'org.hibernate.orm'
+						artifactId = project.name
+						version = project.version
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This renames the module `hibernate-jpamodelgen` to `hibernate-processor`, along with a relocation.

For HHH-17865.